### PR TITLE
bugfix: add banned parameter in user list

### DIFF
--- a/src/containers/Users/index.js
+++ b/src/containers/Users/index.js
@@ -66,7 +66,7 @@ class Users extends Component {
     //if user hits bottom, load next batch of items
     const scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
     if ((window.innerHeight + scrollTop) >= document.body.scrollHeight) {
-      this.loadUsers(stats.users.length, searchString);
+      this.loadUsers(stats.users.length, false, searchString);
     }
   };
   componentDidMount() {


### PR DESCRIPTION
This should fix the scrolling but in the user list, the banned parameter was missing from a call to the loadUser function.